### PR TITLE
Fix numpy TypeError.

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -46,7 +46,7 @@ Example
     @batching(max_batch_size=32)
     class MyModel:
         def __init__(self, k, n):
-            self.weights = np.random.randn((k, n)).astype("f")
+            self.weights = np.random.randn(k, n).astype("f")
 
         # x: [batch_size, m, k], self.weights: [k, n]
         def predict_batch(self, x):


### PR DESCRIPTION
Get `TypeError: 'tuple' object cannot be interpreted as an integer` when run `np.random.randn((3,3))`. 

Numpy version: `1.26.4`.